### PR TITLE
Fix the issue of using gclient.bat on Windows platform

### DIFF
--- a/src/chrome_builder.js
+++ b/src/chrome_builder.js
@@ -8,6 +8,7 @@ const path = require('path');
 const rimraf = require('rimraf');
 const {spawn} = require('child_process');
 const crypto = require('crypto');
+const os = require('os');
 
 /**
  * Chrome builder class.
@@ -105,7 +106,7 @@ class ChromeBuilder {
     this.conf_.logger.info('Action sync');
 
     await this.childCommand('git', ['pull', '--rebase']);
-    await this.childCommand('gclient', ['sync']);
+    await this.childCommand(os.platform() == 'win32' ? 'gclient.bat' : 'gclient', ['sync']);
 
     if (!this.childResult_.success) {
       await this.uploadLogfile();


### PR DESCRIPTION
In order to support nightly windows build.

Below are error messages:

events.js:183
      throw er; // Unhandled 'error' event
Error: spawn gclient ENOENT
    at _errnoException (util.js:992:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
    at onErrorNT (internal/child_process.js:372:16)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)