### PR TITLE
Remove reject in childCommand method

### DIFF
--- a/src/chrome_builder.js
+++ b/src/chrome_builder.js
@@ -258,7 +258,6 @@ class ChromeBuilder {
 
       child.stderr.on('data', (data) => {
         this.conf_.logger.error(data.toString());
-        reject();
       });
 
       child.on('close', (code) => {


### PR DESCRIPTION
Git pull will return error, but it's successful in fact, so it will trigger childCommand reject case.

Below are git pull logs:
debug: Action: all
info: Execute command: git rev-parse HEAD
debug: 9a86dfe46ebfacb4e656aaae9dafe92fe59d0db7

info: HEAD is at 9a86dfe46ebfacb4e656aaae9dafe92fe59d0db7

info: Action sync
info: Execute command: git pull --rebase
error: From https://github.com/otcshare/chromium-src
   9a86dfe46ebf..007f21581b34  webml      -> origin/webml

(node:21984) UnhandledPromiseRejectionWarning: undefined
(node:21984) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:21984) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
debug: Updating 9a86dfe46ebf..007f21581b34
Fast-forward

debug:  services/ml/compilation_impl_android.cc                      |  2 +-
 services/ml/compilation_impl_linux.cc                        |  4 ++--
 services/ml/compilation_impl_mac.mm                          |  4 ++--
 services/ml/execution_impl_android.cc                        |  2 +-
 services/ml/execution_impl_linux.cc                          |  2 +-
 services/ml/execution_impl_mac.mm                            |  2 +-
 services/ml/model_impl_android.cc                            |  2 +-
 services/ml/model_impl_linux.cc                              | 12 ++++++------